### PR TITLE
Cleanup Makefile/unit testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PKG := "github.com/IlliniBlockchain/$(PROJECT_NAME)"
 PKG_LIST := $(shell go list ${PKG}/... | grep -v /vendor/ | grep -v mocks)
 GO_FILES := $(shell find . -name '*.go' | grep -v /vendor/ | grep -v _test.go)
 
-.PHONY: all dep build clean test coverage coverhtml lint docker.start docker.stop docker.restart test.unit test.integration test.integration.rpcclient
+.PHONY: all dep build clean test coverage coverhtml lint docker.start docker.stop test.unit test.integration test.integration.rpcclient
 
 all: build
 
@@ -19,10 +19,10 @@ docker.start.bitcoin-core: ## Start bitcoin-core docker container
 		-rpcallowip=172.17.0.0/16 \
 		-rpcbind=0.0.0.0 \
 		-rpcuser=test \
-		-rpcpassword=test
+		-rpcpassword=test > /dev/null
 
 docker.stop: ## Stop docker containers
-	@docker stop $$(docker ps -q)
+	@docker stop $$(docker ps -q) > /dev/null
 
 lint: ## Lint the files
 	@golangci-lint run
@@ -38,8 +38,7 @@ test.unit: ## Run unit tests
 test.integration: test.integration.rpcclient ## Run integration tests
 
 test.integration.rpcclient: docker.start.bitcoin-core ## Run rpcclient integration tests
-	@go test -run Integration -run RPCClient ${PKG_LIST}
-	@make docker.stop
+	@go test -run RPCClient ${PKG_LIST}; make docker.stop > /dev/null
 
 race: dep ## Run data race detector
 	@go test -race -short ${PKG_LIST}

--- a/client/rpc/rpcclient_test.go
+++ b/client/rpc/rpcclient_test.go
@@ -68,11 +68,9 @@ func (suite *RPCClientTestSuite) SetupSuite() {
 	genBlockHash, err := genBlockHashReq.Receive()
 	assert.NoError(suite.T(), err)
 	suite.BlockHashes = append([]*chainhash.Hash{genBlockHash}, hashes...)
-
 }
 
 func (suite *RPCClientTestSuite) TestSanityBlockCount() {
-
 	client := suite.Client
 	blockCountReq := client.GetBlockCountAsync()
 	client.Send()
@@ -94,7 +92,6 @@ type HashTest struct {
 }
 
 func GetHashTestTable(suite *RPCClientTestSuite) []HashTest {
-
 	if len(suite.BlockHashes) < 5 {
 		panic("Test blockchain must have 5 or more blocks.")
 	}
@@ -134,11 +131,9 @@ func GetHashTestTable(suite *RPCClientTestSuite) []HashTest {
 			wantErr: true,
 		},
 	}
-
 }
 
 func (suite *RPCClientTestSuite) TestGetHashesByRange() {
-
 	tests := GetHashTestTable(suite)
 	for _, tt := range tests {
 		suite.Run(tt.name, func() {
@@ -154,7 +149,6 @@ func (suite *RPCClientTestSuite) TestGetHashesByRange() {
 }
 
 func (suite *RPCClientTestSuite) TestGetBlocksByRange() {
-
 	tests := GetHashTestTable(suite)
 	for _, tt := range tests {
 		suite.Run(tt.name, func() {
@@ -173,11 +167,9 @@ func (suite *RPCClientTestSuite) TestGetBlocksByRange() {
 			assert.ElementsMatch(suite.T(), tt.want, hashes)
 		})
 	}
-
 }
 
 func (suite *RPCClientTestSuite) TestGetBlocksVerboseByRange() {
-
 	tests := GetHashTestTable(suite)
 	for _, tt := range tests {
 		suite.Run(tt.name, func() {
@@ -199,7 +191,6 @@ func (suite *RPCClientTestSuite) TestGetBlocksVerboseByRange() {
 }
 
 func (suite *RPCClientTestSuite) TestGetBlocksVerboseTxByRange() {
-
 	tests := GetHashTestTable(suite)
 	for _, tt := range tests {
 		suite.Run(tt.name, func() {
@@ -218,9 +209,11 @@ func (suite *RPCClientTestSuite) TestGetBlocksVerboseTxByRange() {
 			assert.ElementsMatch(suite.T(), tt.want, hashes)
 		})
 	}
-
 }
 
 func TestRPCClientTestSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode.")
+	}
 	suite.Run(t, new(RPCClientTestSuite))
 }


### PR DESCRIPTION
Just some small changes to take care of #2 and add a line to not run rpcclient tests for unit tests from `-short` flag.