### PR TITLE
Refactor RPCClient to use new types

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"github.com/IlliniBlockchain/etl-bitcoin/types"
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
@@ -31,12 +32,25 @@ type Client interface {
 	GetTxOut(txHash *chainhash.Hash, index uint32, mempool bool) (*btcjson.GetTxOutResult, error)
 	// GetRawMempool returns the hashes of all transactions in the memory pool.
 	GetRawMempool() ([]*chainhash.Hash, error)
-	// GetBlocksByRange returns raw blocks from the server given a range of block numbers.
-	GetBlocksByRange(minBlockNumber, maxBlockNumber int64) ([]*wire.MsgBlock, error)
-	// GetBlocksVerboseByRange returns data structures from the server with information
-	// about block given a range of block numbers.
-	GetBlocksVerboseByRange(minBlockNumber, maxBlockNumber int64) ([]*btcjson.GetBlockVerboseResult, error)
-	// GetBlocksVerboseTxByRange returns data structures from the server with information
-	// about blocks and their transactions given a range of block numbers.
-	GetBlocksVerboseTxByRange(minBlockNumber, maxBlockNumber int64) ([]*btcjson.GetBlockVerboseTxResult, error)
+	// // GetBlocksByRange returns raw blocks from the server given a range of block numbers.
+	// GetBlocksByRange(minBlockNumber, maxBlockNumber int64) ([]*wire.MsgBlock, error)
+	// // GetBlocksVerboseByRange returns data structures from the server with information
+	// // about block given a range of block numbers.
+	// GetBlocksVerboseByRange(minBlockNumber, maxBlockNumber int64) ([]*btcjson.GetBlockVerboseResult, error)
+	// // GetBlocksVerboseTxByRange returns data structures from the server with information
+	// // about blocks and their transactions given a range of block numbers.
+	// GetBlocksVerboseTxByRange(minBlockNumber, maxBlockNumber int64) ([]*btcjson.GetBlockVerboseTxResult, error)
+
+	// GetBlockHashesByRange returns block hashes from the server given a range (inclusive) of block numbers.
+	// Hashes are returned in order from `minBlockNumber` to `maxBlockNumber`
+	GetBlockHashesByRange(minBlockNumber, maxBlockNumber int64) ([]*chainhash.Hash, error)
+	// GetBlockHeadersByHashes returns block headers from the server given a list of block hashes.
+	GetBlockHeadersByHashes(hashes []*chainhash.Hash) ([]*types.BlockHeader, error)
+	// GetBlocksByHashes returns blocks with transactions from the server given a list of block hashes.
+	GetBlocksByHashes(hashes []*chainhash.Hash) ([]*types.Block, error)
+	// GetBlockHeadersByRange returns raw blocks from the server given a range of block numbers.
+	GetBlockHeadersByRange(minBlockNumber, maxBlockNumber int64) ([]*types.BlockHeader, error)
+	// GetBlocksByRange returns data structures from the server with information about
+	// blocks and their transactions given a range of block numbers.
+	GetBlocksByRange(minBlockNumber, maxBlockNumber int64) ([]*types.Block, error)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -32,25 +32,11 @@ type Client interface {
 	GetTxOut(txHash *chainhash.Hash, index uint32, mempool bool) (*btcjson.GetTxOutResult, error)
 	// GetRawMempool returns the hashes of all transactions in the memory pool.
 	GetRawMempool() ([]*chainhash.Hash, error)
-	// // GetBlocksByRange returns raw blocks from the server given a range of block numbers.
-	// GetBlocksByRange(minBlockNumber, maxBlockNumber int64) ([]*wire.MsgBlock, error)
-	// // GetBlocksVerboseByRange returns data structures from the server with information
-	// // about block given a range of block numbers.
-	// GetBlocksVerboseByRange(minBlockNumber, maxBlockNumber int64) ([]*btcjson.GetBlockVerboseResult, error)
-	// // GetBlocksVerboseTxByRange returns data structures from the server with information
-	// // about blocks and their transactions given a range of block numbers.
-	// GetBlocksVerboseTxByRange(minBlockNumber, maxBlockNumber int64) ([]*btcjson.GetBlockVerboseTxResult, error)
-
 	// GetBlockHashesByRange returns block hashes from the server given a range (inclusive) of block numbers.
 	// Hashes are returned in order from `minBlockNumber` to `maxBlockNumber`
 	GetBlockHashesByRange(minBlockNumber, maxBlockNumber int64) ([]*chainhash.Hash, error)
-	// GetBlockHeadersByHashes returns block headers from the server given a list of block hashes.
-	GetBlockHeadersByHashes(hashes []*chainhash.Hash) ([]*types.BlockHeader, error)
-	// GetBlocksByHashes returns blocks with transactions from the server given a list of block hashes.
-	GetBlocksByHashes(hashes []*chainhash.Hash) ([]*types.Block, error)
-	// GetBlockHeadersByRange returns raw blocks from the server given a range of block numbers.
-	GetBlockHeadersByRange(minBlockNumber, maxBlockNumber int64) ([]*types.BlockHeader, error)
-	// GetBlocksByRange returns data structures from the server with information about
-	// blocks and their transactions given a range of block numbers.
-	GetBlocksByRange(minBlockNumber, maxBlockNumber int64) ([]*types.Block, error)
+	// GetBlockHeadersByRange returns block headers from the server given a list/range of block hashes.
+	GetBlockHeadersByRange(hashes []*chainhash.Hash) ([]*types.BlockHeader, error)
+	// GetBlocksByRange returns blocks with transactions from the server given a list/range of block hashes.
+	GetBlocksByRange(hashes []*chainhash.Hash) ([]*types.Block, error)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -36,7 +36,7 @@ type Client interface {
 	// Hashes are returned in order from `minBlockNumber` to `maxBlockNumber`
 	GetBlockHashesByRange(minBlockNumber, maxBlockNumber int64) ([]*chainhash.Hash, error)
 	// GetBlockHeadersByRange returns block headers from the server given a list/range of block hashes.
-	GetBlockHeadersByRange(hashes []*chainhash.Hash) ([]*types.BlockHeader, error)
+	GetBlockHeaders(hashes []*chainhash.Hash) ([]*types.BlockHeader, error)
 	// GetBlocksByRange returns blocks with transactions from the server given a list/range of block hashes.
-	GetBlocksByRange(hashes []*chainhash.Hash) ([]*types.Block, error)
+	GetBlocks(hashes []*chainhash.Hash) ([]*types.Block, error)
 }

--- a/client/rpc/rpcclient.go
+++ b/client/rpc/rpcclient.go
@@ -58,8 +58,8 @@ func (client *RPCClient) GetBlockHashesByRange(minBlockNumber, maxBlockNumber in
 	return blockHashes, nil
 }
 
-// GetBlockHeadersByHashes returns block headers from the server given a list of block hashes.
-func (client *RPCClient) GetBlockHeadersByHashes(hashes []*chainhash.Hash) (blockHeaders []*types.BlockHeader, err error) {
+// GetBlockHeadersByRange returns block headers from the server given a list/range of block hashes.
+func (client *RPCClient) GetBlockHeadersByRange(hashes []*chainhash.Hash) (blockHeaders []*types.BlockHeader, err error) {
 	// Queue block requests
 	blockReqs := make([]rpcclient.FutureGetBlockHeaderVerboseResult, len(hashes))
 	for i, blockHash := range hashes {
@@ -79,8 +79,8 @@ func (client *RPCClient) GetBlockHeadersByHashes(hashes []*chainhash.Hash) (bloc
 	return blockHeaders, nil
 }
 
-// GetBlocksByHashes returns blocks with transactions from the server given a list of block hashes.
-func (client *RPCClient) GetBlocksByHashes(hashes []*chainhash.Hash) (blocks []*types.Block, err error) {
+// GetBlocksByRange returns blocks with transactions from the server given a list/range of block hashes.
+func (client *RPCClient) GetBlocksByRange(hashes []*chainhash.Hash) (blocks []*types.Block, err error) {
 	// Queue block requests
 	blockReqs := make([]rpcclient.FutureGetBlockVerboseTxResult, len(hashes))
 	for i, blockHash := range hashes {
@@ -99,133 +99,3 @@ func (client *RPCClient) GetBlocksByHashes(hashes []*chainhash.Hash) (blocks []*
 	}
 	return blocks, nil
 }
-
-// GetBlockHeadersByRange returns raw blocks from the server given a range of block numbers.
-func (client *RPCClient) GetBlockHeadersByRange(minBlockNumber, maxBlockNumber int64) (blockHeaders []*types.BlockHeader, err error) {
-	blockHashes, err := client.GetBlockHashesByRange(minBlockNumber, maxBlockNumber)
-	if err != nil {
-		return nil, err
-	}
-	blockHeaders, err = client.GetBlockHeadersByHashes(blockHashes)
-	if err != nil {
-		return nil, err
-	}
-	return blockHeaders, nil
-}
-
-// GetBlocksByRange returns data structures from the server with information about
-// blocks and their transactions given a range of block numbers.
-func (client *RPCClient) GetBlocksByRange(minBlockNumber, maxBlockNumber int64) (blocks []*types.Block, err error) {
-	blockHashes, err := client.GetBlockHashesByRange(minBlockNumber, maxBlockNumber)
-	if err != nil {
-		return nil, err
-	}
-	blocks, err = client.GetBlocksByHashes(blockHashes)
-	if err != nil {
-		return nil, err
-	}
-	return blocks, nil
-}
-
-// // getBlocksByHashes returns raw blocks from the server given a list of block hashes.
-// func (client *RPCClient) getBlocksByHashes(hashes []*chainhash.Hash) (blocks []*wire.MsgBlock, err error) {
-// 	// Queue block requests
-// 	blockReqs := make([]rpcclient.FutureGetBlockResult, len(hashes))
-// 	for i, blockHash := range hashes {
-// 		blockReqs[i] = client.GetBlockAsync(blockHash)
-// 	}
-// 	// Send
-// 	client.Send()
-// 	// Receive block requests
-// 	blocks = make([]*wire.MsgBlock, len(hashes))
-// 	for i, req := range blockReqs {
-// 		blocks[i], err = req.Receive()
-// 		if err != nil {
-// 			return nil, err
-// 		}
-// 	}
-// 	return blocks, nil
-// }
-
-// // getBlocksVerboseByHashes returns data structures from the server with information
-// // about block given a list of block hashes.
-// func (client *RPCClient) getBlocksVerboseByHashes(hashes []*chainhash.Hash) (blocks []*btcjson.GetBlockVerboseResult, err error) {
-// 	// Queue block requests
-// 	blockReqs := make([]rpcclient.FutureGetBlockVerboseResult, len(hashes))
-// 	for i, blockHash := range hashes {
-// 		blockReqs[i] = client.GetBlockVerboseAsync(blockHash)
-// 	}
-// 	// Send
-// 	client.Send()
-// 	// Receive block requests
-// 	blocks = make([]*btcjson.GetBlockVerboseResult, len(hashes))
-// 	for i, req := range blockReqs {
-// 		blocks[i], err = req.Receive()
-// 		if err != nil {
-// 			return nil, err
-// 		}
-// 	}
-// 	return blocks, nil
-// }
-
-// // getBlocksVerboseTxByHashes returns data structures from the server with information
-// // about blocks and their transactions given a list of block hashes.
-// func (client *RPCClient) getBlocksVerboseTxByHashes(hashes []*chainhash.Hash) (blocks []*btcjson.GetBlockVerboseTxResult, err error) {
-// 	// Queue block requests
-// 	blockReqs := make([]rpcclient.FutureGetBlockVerboseTxResult, len(hashes))
-// 	for i, blockHash := range hashes {
-// 		blockReqs[i] = client.GetBlockVerboseTxAsync(blockHash)
-// 	}
-// 	// Send
-// 	client.Send()
-// 	// Receive block requests
-// 	blocks = make([]*btcjson.GetBlockVerboseTxResult, len(hashes))
-// 	for i, req := range blockReqs {
-// 		blocks[i], err = req.Receive()
-// 		if err != nil {
-// 			return nil, err
-// 		}
-// 	}
-// 	return blocks, nil
-// }
-
-// // GetBlocksByRange returns raw blocks from the server given a range (inclusive) of block numbers.
-// func (client *RPCClient) GetBlocksByRange(minBlockNumber, maxBlockNumber int64) (blocks []*wire.MsgBlock, err error) {
-// 	blockHashes, err := client.GetBlockHashesByRange(minBlockNumber, maxBlockNumber)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	blocks, err = client.getBlocksByHashes(blockHashes)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	return blocks, nil
-// }
-
-// // GetBlocksVerboseByRange returns data structures from the server with information
-// // about block given a range of block numbers.
-// func (client *RPCClient) GetBlocksVerboseByRange(minBlockNumber, maxBlockNumber int64) (blocks []*btcjson.GetBlockVerboseResult, err error) {
-// 	hashes, err := client.GetBlockHashesByRange(minBlockNumber, maxBlockNumber)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	blocks, err = client.getBlocksVerboseByHashes(hashes)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	return blocks, nil
-// }
-
-// // GetBlocksVerboseTxByRange returns data structures from the server with information
-// // about blocks and their transactions given a range of block numbers.
-// func (client *RPCClient) GetBlocksVerboseTxByRange(minBlockNumber, maxBlockNumber int64) (blocks []*btcjson.GetBlockVerboseTxResult, err error) {
-// 	hashes, err := client.GetBlockHashesByRange(minBlockNumber, maxBlockNumber)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	blocks, err = client.getBlocksVerboseTxByHashes(hashes)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	return blocks, nil
-// }

--- a/client/rpc/rpcclient.go
+++ b/client/rpc/rpcclient.go
@@ -24,7 +24,6 @@ func New(config *rpcclient.ConnConfig, ntfnHandlers *rpcclient.NotificationHandl
 	client := RPCClient{
 		internal_client,
 	}
-
 	return &client, nil
 }
 

--- a/client/rpc/rpcclient.go
+++ b/client/rpc/rpcclient.go
@@ -24,6 +24,7 @@ func New(config *rpcclient.ConnConfig, ntfnHandlers *rpcclient.NotificationHandl
 	client := RPCClient{
 		internal_client,
 	}
+
 	return &client, nil
 }
 

--- a/client/rpc/rpcclient.go
+++ b/client/rpc/rpcclient.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/btcsuite/btcd/btcjson"
+	"github.com/IlliniBlockchain/etl-bitcoin/types"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/rpcclient"
-	"github.com/btcsuite/btcd/wire"
 )
 
 // RPCClient represents a JSON RPC connection to a bitcoin node.
@@ -59,50 +58,29 @@ func (client *RPCClient) GetBlockHashesByRange(minBlockNumber, maxBlockNumber in
 	return blockHashes, nil
 }
 
-// getBlocksByHashes returns raw blocks from the server given a list of block hashes.
-func (client *RPCClient) getBlocksByHashes(hashes []*chainhash.Hash) (blocks []*wire.MsgBlock, err error) {
+// GetBlockHeadersByHashes returns block headers from the server given a list of block hashes.
+func (client *RPCClient) GetBlockHeadersByHashes(hashes []*chainhash.Hash) (blockHeaders []*types.BlockHeader, err error) {
 	// Queue block requests
-	blockReqs := make([]rpcclient.FutureGetBlockResult, len(hashes))
+	blockReqs := make([]rpcclient.FutureGetBlockHeaderVerboseResult, len(hashes))
 	for i, blockHash := range hashes {
-		blockReqs[i] = client.GetBlockAsync(blockHash)
+		blockReqs[i] = client.GetBlockHeaderVerboseAsync(blockHash)
 	}
 	// Send
 	client.Send()
 	// Receive block requests
-	blocks = make([]*wire.MsgBlock, len(hashes))
+	blockHeaders = make([]*types.BlockHeader, len(hashes))
 	for i, req := range blockReqs {
-		blocks[i], err = req.Receive()
+		block, err := req.Receive()
 		if err != nil {
 			return nil, err
 		}
+		blockHeaders[i] = types.NewBlockHeader(*block)
 	}
-	return blocks, nil
+	return blockHeaders, nil
 }
 
-// getBlocksVerboseByHashes returns data structures from the server with information
-// about block given a list of block hashes.
-func (client *RPCClient) getBlocksVerboseByHashes(hashes []*chainhash.Hash) (blocks []*btcjson.GetBlockVerboseResult, err error) {
-	// Queue block requests
-	blockReqs := make([]rpcclient.FutureGetBlockVerboseResult, len(hashes))
-	for i, blockHash := range hashes {
-		blockReqs[i] = client.GetBlockVerboseAsync(blockHash)
-	}
-	// Send
-	client.Send()
-	// Receive block requests
-	blocks = make([]*btcjson.GetBlockVerboseResult, len(hashes))
-	for i, req := range blockReqs {
-		blocks[i], err = req.Receive()
-		if err != nil {
-			return nil, err
-		}
-	}
-	return blocks, nil
-}
-
-// getBlocksVerboseTxByHashes returns data structures from the server with information
-// about blocks and their transactions given a list of block hashes.
-func (client *RPCClient) getBlocksVerboseTxByHashes(hashes []*chainhash.Hash) (blocks []*btcjson.GetBlockVerboseTxResult, err error) {
+// GetBlocksByHashes returns blocks with transactions from the server given a list of block hashes.
+func (client *RPCClient) GetBlocksByHashes(hashes []*chainhash.Hash) (blocks []*types.Block, err error) {
 	// Queue block requests
 	blockReqs := make([]rpcclient.FutureGetBlockVerboseTxResult, len(hashes))
 	for i, blockHash := range hashes {
@@ -111,53 +89,143 @@ func (client *RPCClient) getBlocksVerboseTxByHashes(hashes []*chainhash.Hash) (b
 	// Send
 	client.Send()
 	// Receive block requests
-	blocks = make([]*btcjson.GetBlockVerboseTxResult, len(hashes))
+	blocks = make([]*types.Block, len(hashes))
 	for i, req := range blockReqs {
-		blocks[i], err = req.Receive()
+		block, err := req.Receive()
 		if err != nil {
 			return nil, err
 		}
+		blocks[i] = types.NewBlock(*block)
 	}
 	return blocks, nil
 }
 
-// GetBlocksByRange returns raw blocks from the server given a range (inclusive) of block numbers.
-func (client *RPCClient) GetBlocksByRange(minBlockNumber, maxBlockNumber int64) (blocks []*wire.MsgBlock, err error) {
+// GetBlockHeadersByRange returns raw blocks from the server given a range of block numbers.
+func (client *RPCClient) GetBlockHeadersByRange(minBlockNumber, maxBlockNumber int64) (blockHeaders []*types.BlockHeader, err error) {
 	blockHashes, err := client.GetBlockHashesByRange(minBlockNumber, maxBlockNumber)
 	if err != nil {
 		return nil, err
 	}
-	blocks, err = client.getBlocksByHashes(blockHashes)
+	blockHeaders, err = client.GetBlockHeadersByHashes(blockHashes)
+	if err != nil {
+		return nil, err
+	}
+	return blockHeaders, nil
+}
+
+// GetBlocksByRange returns data structures from the server with information about
+// blocks and their transactions given a range of block numbers.
+func (client *RPCClient) GetBlocksByRange(minBlockNumber, maxBlockNumber int64) (blocks []*types.Block, err error) {
+	blockHashes, err := client.GetBlockHashesByRange(minBlockNumber, maxBlockNumber)
+	if err != nil {
+		return nil, err
+	}
+	blocks, err = client.GetBlocksByHashes(blockHashes)
 	if err != nil {
 		return nil, err
 	}
 	return blocks, nil
 }
 
-// GetBlocksVerboseByRange returns data structures from the server with information
-// about block given a range of block numbers.
-func (client *RPCClient) GetBlocksVerboseByRange(minBlockNumber, maxBlockNumber int64) (blocks []*btcjson.GetBlockVerboseResult, err error) {
-	hashes, err := client.GetBlockHashesByRange(minBlockNumber, maxBlockNumber)
-	if err != nil {
-		return nil, err
-	}
-	blocks, err = client.getBlocksVerboseByHashes(hashes)
-	if err != nil {
-		return nil, err
-	}
-	return blocks, nil
-}
+// // getBlocksByHashes returns raw blocks from the server given a list of block hashes.
+// func (client *RPCClient) getBlocksByHashes(hashes []*chainhash.Hash) (blocks []*wire.MsgBlock, err error) {
+// 	// Queue block requests
+// 	blockReqs := make([]rpcclient.FutureGetBlockResult, len(hashes))
+// 	for i, blockHash := range hashes {
+// 		blockReqs[i] = client.GetBlockAsync(blockHash)
+// 	}
+// 	// Send
+// 	client.Send()
+// 	// Receive block requests
+// 	blocks = make([]*wire.MsgBlock, len(hashes))
+// 	for i, req := range blockReqs {
+// 		blocks[i], err = req.Receive()
+// 		if err != nil {
+// 			return nil, err
+// 		}
+// 	}
+// 	return blocks, nil
+// }
 
-// GetBlocksVerboseTxByRange returns data structures from the server with information
-// about blocks and their transactions given a range of block numbers.
-func (client *RPCClient) GetBlocksVerboseTxByRange(minBlockNumber, maxBlockNumber int64) (blocks []*btcjson.GetBlockVerboseTxResult, err error) {
-	hashes, err := client.GetBlockHashesByRange(minBlockNumber, maxBlockNumber)
-	if err != nil {
-		return nil, err
-	}
-	blocks, err = client.getBlocksVerboseTxByHashes(hashes)
-	if err != nil {
-		return nil, err
-	}
-	return blocks, nil
-}
+// // getBlocksVerboseByHashes returns data structures from the server with information
+// // about block given a list of block hashes.
+// func (client *RPCClient) getBlocksVerboseByHashes(hashes []*chainhash.Hash) (blocks []*btcjson.GetBlockVerboseResult, err error) {
+// 	// Queue block requests
+// 	blockReqs := make([]rpcclient.FutureGetBlockVerboseResult, len(hashes))
+// 	for i, blockHash := range hashes {
+// 		blockReqs[i] = client.GetBlockVerboseAsync(blockHash)
+// 	}
+// 	// Send
+// 	client.Send()
+// 	// Receive block requests
+// 	blocks = make([]*btcjson.GetBlockVerboseResult, len(hashes))
+// 	for i, req := range blockReqs {
+// 		blocks[i], err = req.Receive()
+// 		if err != nil {
+// 			return nil, err
+// 		}
+// 	}
+// 	return blocks, nil
+// }
+
+// // getBlocksVerboseTxByHashes returns data structures from the server with information
+// // about blocks and their transactions given a list of block hashes.
+// func (client *RPCClient) getBlocksVerboseTxByHashes(hashes []*chainhash.Hash) (blocks []*btcjson.GetBlockVerboseTxResult, err error) {
+// 	// Queue block requests
+// 	blockReqs := make([]rpcclient.FutureGetBlockVerboseTxResult, len(hashes))
+// 	for i, blockHash := range hashes {
+// 		blockReqs[i] = client.GetBlockVerboseTxAsync(blockHash)
+// 	}
+// 	// Send
+// 	client.Send()
+// 	// Receive block requests
+// 	blocks = make([]*btcjson.GetBlockVerboseTxResult, len(hashes))
+// 	for i, req := range blockReqs {
+// 		blocks[i], err = req.Receive()
+// 		if err != nil {
+// 			return nil, err
+// 		}
+// 	}
+// 	return blocks, nil
+// }
+
+// // GetBlocksByRange returns raw blocks from the server given a range (inclusive) of block numbers.
+// func (client *RPCClient) GetBlocksByRange(minBlockNumber, maxBlockNumber int64) (blocks []*wire.MsgBlock, err error) {
+// 	blockHashes, err := client.GetBlockHashesByRange(minBlockNumber, maxBlockNumber)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	blocks, err = client.getBlocksByHashes(blockHashes)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	return blocks, nil
+// }
+
+// // GetBlocksVerboseByRange returns data structures from the server with information
+// // about block given a range of block numbers.
+// func (client *RPCClient) GetBlocksVerboseByRange(minBlockNumber, maxBlockNumber int64) (blocks []*btcjson.GetBlockVerboseResult, err error) {
+// 	hashes, err := client.GetBlockHashesByRange(minBlockNumber, maxBlockNumber)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	blocks, err = client.getBlocksVerboseByHashes(hashes)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	return blocks, nil
+// }
+
+// // GetBlocksVerboseTxByRange returns data structures from the server with information
+// // about blocks and their transactions given a range of block numbers.
+// func (client *RPCClient) GetBlocksVerboseTxByRange(minBlockNumber, maxBlockNumber int64) (blocks []*btcjson.GetBlockVerboseTxResult, err error) {
+// 	hashes, err := client.GetBlockHashesByRange(minBlockNumber, maxBlockNumber)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	blocks, err = client.getBlocksVerboseTxByHashes(hashes)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	return blocks, nil
+// }

--- a/client/rpc/rpcclient.go
+++ b/client/rpc/rpcclient.go
@@ -27,9 +27,9 @@ func New(config *rpcclient.ConnConfig, ntfnHandlers *rpcclient.NotificationHandl
 	return &client, nil
 }
 
-// getBlockHashesByRange returns block hashes from the server given a range (inclusive) of block numbers.
+// GetBlockHashesByRange returns block hashes from the server given a range (inclusive) of block numbers.
 // Hashes are returned in order from `minBlockNumber` to `maxBlockNumber`
-func (client *RPCClient) getBlockHashesByRange(minBlockNumber, maxBlockNumber int64) (hashes []*chainhash.Hash, err error) {
+func (client *RPCClient) GetBlockHashesByRange(minBlockNumber, maxBlockNumber int64) (hashes []*chainhash.Hash, err error) {
 	if minBlockNumber > maxBlockNumber {
 		log.Printf("minBlockNumber: %d\tmaxBlockNumber: %d\n", minBlockNumber, maxBlockNumber)
 		return nil, fmt.Errorf(
@@ -123,7 +123,7 @@ func (client *RPCClient) getBlocksVerboseTxByHashes(hashes []*chainhash.Hash) (b
 
 // GetBlocksByRange returns raw blocks from the server given a range (inclusive) of block numbers.
 func (client *RPCClient) GetBlocksByRange(minBlockNumber, maxBlockNumber int64) (blocks []*wire.MsgBlock, err error) {
-	blockHashes, err := client.getBlockHashesByRange(minBlockNumber, maxBlockNumber)
+	blockHashes, err := client.GetBlockHashesByRange(minBlockNumber, maxBlockNumber)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func (client *RPCClient) GetBlocksByRange(minBlockNumber, maxBlockNumber int64) 
 // GetBlocksVerboseByRange returns data structures from the server with information
 // about block given a range of block numbers.
 func (client *RPCClient) GetBlocksVerboseByRange(minBlockNumber, maxBlockNumber int64) (blocks []*btcjson.GetBlockVerboseResult, err error) {
-	hashes, err := client.getBlockHashesByRange(minBlockNumber, maxBlockNumber)
+	hashes, err := client.GetBlockHashesByRange(minBlockNumber, maxBlockNumber)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func (client *RPCClient) GetBlocksVerboseByRange(minBlockNumber, maxBlockNumber 
 // GetBlocksVerboseTxByRange returns data structures from the server with information
 // about blocks and their transactions given a range of block numbers.
 func (client *RPCClient) GetBlocksVerboseTxByRange(minBlockNumber, maxBlockNumber int64) (blocks []*btcjson.GetBlockVerboseTxResult, err error) {
-	hashes, err := client.getBlockHashesByRange(minBlockNumber, maxBlockNumber)
+	hashes, err := client.GetBlockHashesByRange(minBlockNumber, maxBlockNumber)
 	if err != nil {
 		return nil, err
 	}

--- a/client/rpc/rpcclient.go
+++ b/client/rpc/rpcclient.go
@@ -59,7 +59,7 @@ func (client *RPCClient) GetBlockHashesByRange(minBlockNumber, maxBlockNumber in
 }
 
 // GetBlockHeadersByRange returns block headers from the server given a list/range of block hashes.
-func (client *RPCClient) GetBlockHeadersByRange(hashes []*chainhash.Hash) (blockHeaders []*types.BlockHeader, err error) {
+func (client *RPCClient) GetBlockHeaders(hashes []*chainhash.Hash) (blockHeaders []*types.BlockHeader, err error) {
 	// Queue block requests
 	blockReqs := make([]rpcclient.FutureGetBlockHeaderVerboseResult, len(hashes))
 	for i, blockHash := range hashes {
@@ -80,7 +80,7 @@ func (client *RPCClient) GetBlockHeadersByRange(hashes []*chainhash.Hash) (block
 }
 
 // GetBlocksByRange returns blocks with transactions from the server given a list/range of block hashes.
-func (client *RPCClient) GetBlocksByRange(hashes []*chainhash.Hash) (blocks []*types.Block, err error) {
+func (client *RPCClient) GetBlocks(hashes []*chainhash.Hash) (blocks []*types.Block, err error) {
 	// Queue block requests
 	blockReqs := make([]rpcclient.FutureGetBlockVerboseTxResult, len(hashes))
 	for i, blockHash := range hashes {

--- a/client/rpc/rpcclient_test.go
+++ b/client/rpc/rpcclient_test.go
@@ -148,7 +148,7 @@ func (suite *RPCClientTestSuite) TestGetHashesByRange() {
 	}
 }
 
-func (suite *RPCClientTestSuite) TestGetBlockHeadersByRange() {
+func (suite *RPCClientTestSuite) TestGetBlockHeaders() {
 	tests := GetHashTestTable(suite)
 	for _, tt := range tests {
 		suite.Run(tt.name, func() {
@@ -157,7 +157,7 @@ func (suite *RPCClientTestSuite) TestGetBlockHeadersByRange() {
 				assert.Error(suite.T(), err)
 				return
 			}
-			blockHeaders, err := suite.Client.GetBlockHeadersByRange(hashes)
+			blockHeaders, err := suite.Client.GetBlockHeaders(hashes)
 			assert.NoError(suite.T(), err)
 
 			blockHeaderHashes := make([]*chainhash.Hash, len(blockHeaders))
@@ -171,7 +171,7 @@ func (suite *RPCClientTestSuite) TestGetBlockHeadersByRange() {
 	}
 }
 
-func (suite *RPCClientTestSuite) TestGetBlocksByRange() {
+func (suite *RPCClientTestSuite) TestGetBlocks() {
 	tests := GetHashTestTable(suite)
 	for _, tt := range tests {
 		suite.Run(tt.name, func() {
@@ -180,7 +180,7 @@ func (suite *RPCClientTestSuite) TestGetBlocksByRange() {
 				assert.Error(suite.T(), err)
 				return
 			}
-			blocks, err := suite.Client.GetBlocksByRange(hashes)
+			blocks, err := suite.Client.GetBlocks(hashes)
 			assert.NoError(suite.T(), err)
 
 			blockHashes := make([]*chainhash.Hash, len(blocks))

--- a/client/rpc/rpcclient_test.go
+++ b/client/rpc/rpcclient_test.go
@@ -137,7 +137,7 @@ func (suite *RPCClientTestSuite) TestGetHashesByRange() {
 	tests := GetHashTestTable(suite)
 	for _, tt := range tests {
 		suite.Run(tt.name, func() {
-			hashes, err := suite.Client.getBlockHashesByRange(tt.args.minBlockNumber, tt.args.maxBlockNumber)
+			hashes, err := suite.Client.GetBlockHashesByRange(tt.args.minBlockNumber, tt.args.maxBlockNumber)
 			if tt.wantErr {
 				assert.Error(suite.T(), err)
 				return

--- a/client/rpc/rpcclient_test.go
+++ b/client/rpc/rpcclient_test.go
@@ -152,20 +152,21 @@ func (suite *RPCClientTestSuite) TestGetBlockHeadersByRange() {
 	tests := GetHashTestTable(suite)
 	for _, tt := range tests {
 		suite.Run(tt.name, func() {
-			blockHeaders, err := suite.Client.GetBlockHeadersByRange(tt.args.minBlockNumber, tt.args.maxBlockNumber)
+			hashes, err := suite.Client.GetBlockHashesByRange(tt.args.minBlockNumber, tt.args.maxBlockNumber)
 			if tt.wantErr {
 				assert.Error(suite.T(), err)
 				return
 			}
+			blockHeaders, err := suite.Client.GetBlockHeadersByRange(hashes)
 			assert.NoError(suite.T(), err)
 
-			hashes := make([]*chainhash.Hash, len(blockHeaders))
+			blockHeaderHashes := make([]*chainhash.Hash, len(blockHeaders))
 			for i, block := range blockHeaders {
 				hash, err := chainhash.NewHashFromStr(block.Hash())
 				assert.NoError(suite.T(), err)
-				hashes[i] = hash
+				blockHeaderHashes[i] = hash
 			}
-			assert.ElementsMatch(suite.T(), tt.want, hashes)
+			assert.ElementsMatch(suite.T(), tt.want, blockHeaderHashes)
 		})
 	}
 }
@@ -174,87 +175,24 @@ func (suite *RPCClientTestSuite) TestGetBlocksByRange() {
 	tests := GetHashTestTable(suite)
 	for _, tt := range tests {
 		suite.Run(tt.name, func() {
-			blocks, err := suite.Client.GetBlocksByRange(tt.args.minBlockNumber, tt.args.maxBlockNumber)
+			hashes, err := suite.Client.GetBlockHashesByRange(tt.args.minBlockNumber, tt.args.maxBlockNumber)
 			if tt.wantErr {
 				assert.Error(suite.T(), err)
 				return
 			}
+			blocks, err := suite.Client.GetBlocksByRange(hashes)
 			assert.NoError(suite.T(), err)
 
-			hashes := make([]*chainhash.Hash, len(blocks))
+			blockHashes := make([]*chainhash.Hash, len(blocks))
 			for i, block := range blocks {
 				hash, err := chainhash.NewHashFromStr(block.Hash())
 				assert.NoError(suite.T(), err)
-				hashes[i] = hash
+				blockHashes[i] = hash
 			}
-			assert.ElementsMatch(suite.T(), tt.want, hashes)
+			assert.ElementsMatch(suite.T(), tt.want, blockHashes)
 		})
 	}
 }
-
-// func (suite *RPCClientTestSuite) TestGetBlocksByRange() {
-// 	tests := GetHashTestTable(suite)
-// 	for _, tt := range tests {
-// 		suite.Run(tt.name, func() {
-// 			blocks, err := suite.Client.GetBlocksByRange(tt.args.minBlockNumber, tt.args.maxBlockNumber)
-// 			if tt.wantErr {
-// 				assert.Error(suite.T(), err)
-// 				return
-// 			}
-// 			assert.NoError(suite.T(), err)
-
-// 			hashes := make([]*chainhash.Hash, len(blocks))
-// 			for i, block := range blocks {
-// 				hash := block.BlockHash()
-// 				hashes[i] = &hash
-// 			}
-// 			assert.ElementsMatch(suite.T(), tt.want, hashes)
-// 		})
-// 	}
-// }
-
-// func (suite *RPCClientTestSuite) TestGetBlocksVerboseByRange() {
-// 	tests := GetHashTestTable(suite)
-// 	for _, tt := range tests {
-// 		suite.Run(tt.name, func() {
-// 			blocks, err := suite.Client.GetBlocksVerboseByRange(tt.args.minBlockNumber, tt.args.maxBlockNumber)
-// 			if tt.wantErr {
-// 				assert.Error(suite.T(), err)
-// 				return
-// 			}
-// 			assert.NoError(suite.T(), err)
-
-// 			hashes := make([]*chainhash.Hash, len(blocks))
-// 			for i, block := range blocks {
-// 				hashes[i], err = chainhash.NewHashFromStr(block.Hash)
-// 				assert.NoError(suite.T(), err)
-// 			}
-// 			assert.ElementsMatch(suite.T(), tt.want, hashes)
-// 		})
-// 	}
-// }
-
-// func (suite *RPCClientTestSuite) TestGetBlocksVerboseTxByRange() {
-// 	tests := GetHashTestTable(suite)
-// 	for _, tt := range tests {
-// 		suite.Run(tt.name, func() {
-// 			blocks, err := suite.Client.GetBlocksVerboseByRange(tt.args.minBlockNumber, tt.args.maxBlockNumber)
-// 			if tt.wantErr {
-// 				assert.Error(suite.T(), err)
-// 				return
-// 			}
-// 			assert.NoError(suite.T(), err)
-
-// 			hashes := make([]*chainhash.Hash, len(blocks))
-// 			for i, block := range blocks {
-// 				hashes[i], err = chainhash.NewHashFromStr(block.Hash)
-// 				assert.NoError(suite.T(), err)
-// 			}
-// 			assert.ElementsMatch(suite.T(), tt.want, hashes)
-// 		})
-// 	}
-
-// }
 
 func TestRPCClientTestSuite(t *testing.T) {
 	if testing.Short() {

--- a/client/rpc/rpcclient_test.go
+++ b/client/rpc/rpcclient_test.go
@@ -148,6 +148,28 @@ func (suite *RPCClientTestSuite) TestGetHashesByRange() {
 	}
 }
 
+func (suite *RPCClientTestSuite) TestGetBlockHeadersByRange() {
+	tests := GetHashTestTable(suite)
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			blockHeaders, err := suite.Client.GetBlockHeadersByRange(tt.args.minBlockNumber, tt.args.maxBlockNumber)
+			if tt.wantErr {
+				assert.Error(suite.T(), err)
+				return
+			}
+			assert.NoError(suite.T(), err)
+
+			hashes := make([]*chainhash.Hash, len(blockHeaders))
+			for i, block := range blockHeaders {
+				hash, err := chainhash.NewHashFromStr(block.Hash())
+				assert.NoError(suite.T(), err)
+				hashes[i] = hash
+			}
+			assert.ElementsMatch(suite.T(), tt.want, hashes)
+		})
+	}
+}
+
 func (suite *RPCClientTestSuite) TestGetBlocksByRange() {
 	tests := GetHashTestTable(suite)
 	for _, tt := range tests {
@@ -161,56 +183,78 @@ func (suite *RPCClientTestSuite) TestGetBlocksByRange() {
 
 			hashes := make([]*chainhash.Hash, len(blocks))
 			for i, block := range blocks {
-				hash := block.BlockHash()
-				hashes[i] = &hash
-			}
-			assert.ElementsMatch(suite.T(), tt.want, hashes)
-		})
-	}
-}
-
-func (suite *RPCClientTestSuite) TestGetBlocksVerboseByRange() {
-	tests := GetHashTestTable(suite)
-	for _, tt := range tests {
-		suite.Run(tt.name, func() {
-			blocks, err := suite.Client.GetBlocksVerboseByRange(tt.args.minBlockNumber, tt.args.maxBlockNumber)
-			if tt.wantErr {
-				assert.Error(suite.T(), err)
-				return
-			}
-			assert.NoError(suite.T(), err)
-
-			hashes := make([]*chainhash.Hash, len(blocks))
-			for i, block := range blocks {
-				hashes[i], err = chainhash.NewHashFromStr(block.Hash)
+				hash, err := chainhash.NewHashFromStr(block.Hash())
 				assert.NoError(suite.T(), err)
+				hashes[i] = hash
 			}
 			assert.ElementsMatch(suite.T(), tt.want, hashes)
 		})
 	}
 }
 
-func (suite *RPCClientTestSuite) TestGetBlocksVerboseTxByRange() {
-	tests := GetHashTestTable(suite)
-	for _, tt := range tests {
-		suite.Run(tt.name, func() {
-			blocks, err := suite.Client.GetBlocksVerboseByRange(tt.args.minBlockNumber, tt.args.maxBlockNumber)
-			if tt.wantErr {
-				assert.Error(suite.T(), err)
-				return
-			}
-			assert.NoError(suite.T(), err)
+// func (suite *RPCClientTestSuite) TestGetBlocksByRange() {
+// 	tests := GetHashTestTable(suite)
+// 	for _, tt := range tests {
+// 		suite.Run(tt.name, func() {
+// 			blocks, err := suite.Client.GetBlocksByRange(tt.args.minBlockNumber, tt.args.maxBlockNumber)
+// 			if tt.wantErr {
+// 				assert.Error(suite.T(), err)
+// 				return
+// 			}
+// 			assert.NoError(suite.T(), err)
 
-			hashes := make([]*chainhash.Hash, len(blocks))
-			for i, block := range blocks {
-				hashes[i], err = chainhash.NewHashFromStr(block.Hash)
-				assert.NoError(suite.T(), err)
-			}
-			assert.ElementsMatch(suite.T(), tt.want, hashes)
-		})
-	}
+// 			hashes := make([]*chainhash.Hash, len(blocks))
+// 			for i, block := range blocks {
+// 				hash := block.BlockHash()
+// 				hashes[i] = &hash
+// 			}
+// 			assert.ElementsMatch(suite.T(), tt.want, hashes)
+// 		})
+// 	}
+// }
 
-}
+// func (suite *RPCClientTestSuite) TestGetBlocksVerboseByRange() {
+// 	tests := GetHashTestTable(suite)
+// 	for _, tt := range tests {
+// 		suite.Run(tt.name, func() {
+// 			blocks, err := suite.Client.GetBlocksVerboseByRange(tt.args.minBlockNumber, tt.args.maxBlockNumber)
+// 			if tt.wantErr {
+// 				assert.Error(suite.T(), err)
+// 				return
+// 			}
+// 			assert.NoError(suite.T(), err)
+
+// 			hashes := make([]*chainhash.Hash, len(blocks))
+// 			for i, block := range blocks {
+// 				hashes[i], err = chainhash.NewHashFromStr(block.Hash)
+// 				assert.NoError(suite.T(), err)
+// 			}
+// 			assert.ElementsMatch(suite.T(), tt.want, hashes)
+// 		})
+// 	}
+// }
+
+// func (suite *RPCClientTestSuite) TestGetBlocksVerboseTxByRange() {
+// 	tests := GetHashTestTable(suite)
+// 	for _, tt := range tests {
+// 		suite.Run(tt.name, func() {
+// 			blocks, err := suite.Client.GetBlocksVerboseByRange(tt.args.minBlockNumber, tt.args.maxBlockNumber)
+// 			if tt.wantErr {
+// 				assert.Error(suite.T(), err)
+// 				return
+// 			}
+// 			assert.NoError(suite.T(), err)
+
+// 			hashes := make([]*chainhash.Hash, len(blocks))
+// 			for i, block := range blocks {
+// 				hashes[i], err = chainhash.NewHashFromStr(block.Hash)
+// 				assert.NoError(suite.T(), err)
+// 			}
+// 			assert.ElementsMatch(suite.T(), tt.want, hashes)
+// 		})
+// 	}
+
+// }
 
 func TestRPCClientTestSuite(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
Closes #7 

Still did testing just by hashes for now - not sure if/how we want to integrate the block testdata, if we can just test hashes for RPC client tests and test actual data in block tests, etc.

Simplified interface from all the different types of verbosity results to just now have blockheaders and blocks corresponding to our new types.