### PR TITLE
Add Vin & Vout wrapper types for Transactions

### DIFF
--- a/types/block_test.go
+++ b/types/block_test.go
@@ -1,0 +1,82 @@
+package types
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcjson"
+	"github.com/stretchr/testify/suite"
+)
+
+type BlockTestSuite struct {
+	suite.Suite
+	block1000         btcjson.GetBlockVerboseTxResult
+	block409008       btcjson.GetBlockVerboseTxResult
+	blockHeader1000   btcjson.GetBlockHeaderVerboseResult
+	blockHeader409008 btcjson.GetBlockHeaderVerboseResult
+	tx409008          btcjson.TxRawResult
+}
+
+func (s *BlockTestSuite) SetupTest() {
+	s.NoError(parseTestData("testdata/block_1000.json", &s.block1000))
+	s.NoError(parseTestData("testdata/block_409008.json", &s.block409008))
+	s.NoError(parseTestData("testdata/block_header_1000.json", &s.blockHeader1000))
+	s.NoError(parseTestData("testdata/block_header_409008.json", &s.blockHeader409008))
+	s.NoError(parseTestData("testdata/transaction.json", &s.tx409008))
+}
+
+func (s *BlockTestSuite) TestBlockHeaderData() {
+	blk := NewBlockHeader(s.blockHeader409008)
+	s.Equal(s.blockHeader409008.Hash, blk.Hash())
+	s.Equal(s.blockHeader409008.Confirmations, blk.Confirmations())
+	s.Equal(int64(s.blockHeader409008.Height), blk.Height())
+	s.Equal(s.blockHeader409008.Version, blk.Version())
+	s.Equal(s.blockHeader409008.VersionHex, blk.VersionHex())
+	s.Equal(s.blockHeader409008.MerkleRoot, blk.MerkleRoot())
+	s.Equal(s.blockHeader409008.Time, blk.Time())
+	s.Equal(uint32(s.blockHeader409008.Nonce), blk.Nonce())
+	s.Equal(s.blockHeader409008.Bits, blk.Bits())
+	s.Equal(s.blockHeader409008.Difficulty, blk.Difficulty())
+	s.Equal(s.blockHeader409008.PreviousHash, blk.PreviousHash())
+	s.Equal(s.blockHeader409008.NextHash, blk.NextHash())
+}
+
+func (s *BlockTestSuite) TestBlockData() {
+	blk := NewBlock(s.block409008)
+	s.Equal(s.block409008.Hash, blk.Hash())
+	s.Equal(s.block409008.Confirmations, blk.Confirmations())
+	s.Equal(s.block409008.StrippedSize, blk.StrippedSize())
+	s.Equal(s.block409008.Size, blk.Size())
+	s.Equal(s.block409008.Weight, blk.Weight())
+	s.Equal(s.block409008.Height, blk.Height())
+	s.Equal(s.block409008.Version, blk.Version())
+	s.Equal(s.block409008.VersionHex, blk.VersionHex())
+	s.Equal(s.block409008.MerkleRoot, blk.MerkleRoot())
+	s.Equal(s.block409008.Time, blk.Time())
+	s.Equal(s.block409008.Nonce, blk.Nonce())
+	s.Equal(s.block409008.Bits, blk.Bits())
+	s.Equal(s.block409008.Difficulty, blk.Difficulty())
+	s.Equal(s.block409008.PreviousHash, blk.PreviousHash())
+	s.Equal(s.block409008.NextHash, blk.NextHash())
+	s.Len(blk.Transactions(), 1962)
+	for i, tx := range s.block409008.Tx {
+		s.Equal(tx.Txid, blk.Transactions()[i].TxID())
+		s.Equal(i, blk.Transactions()[i].Index())
+	}
+}
+
+func TestBlockTestSuite(t *testing.T) {
+	suite.Run(t, new(BlockTestSuite))
+}
+
+func parseTestData[T any](filename string, v *T) error {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, v); err != nil {
+		return err
+	}
+	return nil
+}

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -12,19 +12,26 @@ import (
 type Transaction struct {
 	data  btcjson.TxRawResult
 	block *Block
+	vin   []*Vin
+	vout  []*Vout
 }
 
 // NewTransaction creates a new transaction from raw json result.
-func NewTransaction(tx btcjson.TxRawResult) *Transaction {
-	return &Transaction{
-		tx,
-		nil,
+func NewTransaction(data btcjson.TxRawResult) *Transaction {
+	tx := &Transaction{
+		data: data,
+		vin:  make([]*Vin, len(data.Vin)),
+		vout: make([]*Vout, len(data.Vout)),
 	}
-}
-
-// NewTransactionWithBlock creates a new transaction from raw json result and its block.
-func NewTransactionWithBlock(tx btcjson.TxRawResult, block *Block) (*Transaction, error) {
-	return NewTransaction(tx).WithBlock(block)
+	for i, vin := range data.Vin {
+		v := vin
+		tx.vin[i] = NewVin(&v)
+	}
+	for i, vout := range data.Vout {
+		v := vout
+		tx.vout[i] = NewVout(&v)
+	}
+	return tx
 }
 
 // WithBlock stores a reference to the block that contains the transaction.
@@ -65,10 +72,10 @@ func (tx *Transaction) Version() uint32 { return tx.data.Version }
 func (tx *Transaction) LockTime() uint32 { return tx.data.LockTime }
 
 // Vin returns the transaction's inputs.
-func (tx *Transaction) Vin() []btcjson.Vin { return tx.data.Vin }
+func (tx *Transaction) Vin() []*Vin { return tx.vin }
 
 // Vout returns the transaction's outputs.
-func (tx *Transaction) Vout() []btcjson.Vout { return tx.data.Vout }
+func (tx *Transaction) Vout() []*Vout { return tx.vout }
 
 // BlockHash returns the hash of the block containing the transaction.
 func (tx *Transaction) BlockHash() string { return tx.data.BlockHash }
@@ -93,5 +100,74 @@ func (tx *Transaction) Block() *Block {
 
 // String implements the Stringer interface.
 func (tx *Transaction) String() string {
-	return tx.TxID()
+	return tx.data.Txid
 }
+
+// Vin represents a Bitcoin transaction input.
+type Vin struct {
+	data *btcjson.Vin
+}
+
+// NewVin creates a new Vin from raw json result.
+func NewVin(vin *btcjson.Vin) *Vin {
+	return &Vin{
+		data: vin,
+	}
+}
+
+// Coinbase returns the coinbase data.
+func (v *Vin) Coinbase() string { return v.data.Coinbase }
+
+// TxID returns the transaction ID.
+func (v *Vin) TxID() string { return v.data.Txid }
+
+// Vout returns the output index.
+func (v *Vin) Vout() uint32 { return v.data.Vout }
+
+// Sequence returns the sequence number.
+func (v *Vin) Sequence() uint32 { return v.data.Sequence }
+
+// ScriptSig returns the scriptSig.
+func (v *Vin) ScriptSig() *btcjson.ScriptSig {
+	if v.data.ScriptSig == nil {
+		return nil
+	}
+	cpy := *v.data.ScriptSig
+	return &cpy
+}
+
+// Witness returns the witnesses of the input.
+func (v *Vin) Witness() []string {
+	if v.data.Witness == nil {
+		return nil
+	}
+	cpy := make([]string, len(v.data.Witness))
+	copy(cpy, v.data.Witness)
+	return cpy
+}
+
+// IsCoinBase returns a bool to show if a Vin is a Coinbase one or not.
+func (v *Vin) IsCoinbase() bool {
+	return len(v.data.Coinbase) > 0
+}
+
+// Vout represents a Bitcoin transaction output.
+type Vout struct {
+	data *btcjson.Vout
+}
+
+// NewVout returns a new instance of a transaction output.
+func NewVout(vout *btcjson.Vout) *Vout {
+	return &Vout{
+		data: vout,
+	}
+}
+
+// Value returns the value of the output.
+func (v *Vout) Value() float64 { return v.data.Value }
+
+// N returns the index of the output.
+func (v *Vout) N() uint32 { return v.data.N }
+
+// ScriptPubKey returns the script of the output.
+func (v *Vout) ScriptPubKey() btcjson.ScriptPubKeyResult { return v.data.ScriptPubKey }

--- a/types/transaction_test.go
+++ b/types/transaction_test.go
@@ -31,13 +31,27 @@ func (s *TransactionTestSuite) TestTransactionData() {
 	s.Equal(s.tx.Weight, tx.Weight())
 	s.Equal(s.tx.Version, tx.Version())
 	s.Equal(s.tx.LockTime, tx.LockTime())
-	s.Equal(s.tx.Vin, tx.Vin())
-	s.Equal(s.tx.Vout, tx.Vout())
 	s.Equal(s.tx.BlockHash, tx.BlockHash())
 	s.Equal(s.tx.Confirmations, tx.Confirmations())
 	s.Equal(s.tx.Time, tx.Time())
 	s.Equal(s.tx.Blocktime, tx.BlockTime())
 	s.Nil(tx.Block())
+	s.Len(tx.Vin(), len(s.tx.Vin))
+	for i, vin := range s.tx.Vin {
+		s.Equal(vin.Coinbase, tx.Vin()[i].Coinbase())
+		s.Equal(vin.Sequence, tx.Vin()[i].Sequence())
+		s.Equal(vin.Txid, tx.Vin()[i].TxID())
+		s.Equal(vin.Vout, tx.Vin()[i].Vout())
+		s.Equal(vin.ScriptSig, tx.Vin()[i].ScriptSig())
+		s.Equal(vin.Witness, tx.Vin()[i].Witness())
+		s.Equal(vin.IsCoinBase(), tx.Vin()[i].IsCoinbase())
+	}
+	s.Len(tx.Vout(), len(s.tx.Vout))
+	for i, vout := range s.tx.Vout {
+		s.Equal(vout.Value, tx.Vout()[i].Value())
+		s.Equal(vout.N, tx.Vout()[i].N())
+		s.Equal(vout.ScriptPubKey, tx.Vout()[i].ScriptPubKey())
+	}
 }
 
 func (s *TransactionTestSuite) TestTransactionWithBlock() {


### PR DESCRIPTION
Cleanup types package by adding custom `Vin` and `Vout` types returned by a `Transaction`. This PR also closes #12 from some basic block tests. Found it weird to work with the regular vin and vout types when creating Neo4j CSV database so I thought I would get this out of the way so we have something concrete to work with. 